### PR TITLE
split vendor chunk using module.context

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -18,7 +18,6 @@ export default ({
     return {
         entry: {
             app: path.join(basePath, 'app.js'),
-            vendor: Object.keys(packageJson.dependencies)
         },
 
         output: {
@@ -38,7 +37,8 @@ export default ({
 
             new webpack.optimize.CommonsChunkPlugin({
                 name: 'vendor',
-                filename: '[name].js'
+                filename: '[name].js',
+                minChunks: module => module.context && module.context.indexOf('node_modules') !== -1,
             }),
 
             new webpack.LoaderOptionsPlugin({ options: { postcss } })


### PR DESCRIPTION
instead of reading `packageJson.dependencies`

This also seems to be documented way: https://webpack.js.org/guides/code-splitting-libraries/#implicit-common-vendor-chunk

Nice boilerplate btw![ I've used it as an example](https://github.com/laggingreflex/preact-minimal) for my [koa-ssr](https://github.com/laggingreflex/koa-ssr) (server-side-rendering) 